### PR TITLE
Do not attempt to decode JWT token when token is missing

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -48,6 +48,8 @@ function JwtClaimsHeadersHandler:access(conf)
 
   if not token and not continue_on_error then
     return responses.send_HTTP_UNAUTHORIZED()
+  elseif not token and continue_on_error then
+    return
   end
 
   local jwt, err = jwt_decoder:new(token)


### PR DESCRIPTION
The kong plugin `kong.plugins.jwt.jwt_parser` throws an error when attempting to decode a nil value this change prevents jwt_decoder from being called when the token is not present and continue_on_error is enabled.

Here is the error, this is running kong v0.14.1
```
[error] 35#0: *972894 lua coroutine: runtime error: ...hare/lua/5.1/kong/plugins/jwt-claims-headers/handler.lua:53: Token must be a string, got nil
stack traceback:
coroutine 0:
	[C]: in function 'error'
	/usr/local/share/lua/5.1/kong/plugins/jwt/jwt_parser.lua:214: in function 'new'
	...hare/lua/5.1/kong/plugins/jwt-claims-headers/handler.lua:53: in function &lt;...hare/lua/5.1/kong/plugins/jwt-claims-headers/handler.lua:40&gt;
coroutine 1:
```