### PR TITLE
doc: fix header name with uppercase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,9 +21,9 @@ convention of `x-<claim-name>`. For example, if the JWT payload object is
 then the following headers would be added
 
 ```
-x-sub   : "1234567890"
-x-name  : "John Doe"
-x-admin : true
+X-Sub   : "1234567890"
+X-Name  : "John Doe"
+X-Admin : true
 ```
 
 ## Configuration


### PR DESCRIPTION
Hello,
First thanks, we used it and it works perfectly 👌 
I've just updated the Readme, when using this plugin, I see that the two first letters of the header name are in uppercase.
Regards,
Alex.